### PR TITLE
feat: crear repositorios JpaRepository para las entidades principales

### DIFF
--- a/src/main/java/com/meta/TaskFlow/repositories/ProyectoRepository.java
+++ b/src/main/java/com/meta/TaskFlow/repositories/ProyectoRepository.java
@@ -1,0 +1,8 @@
+package com.meta.TaskFlow.repositories;
+
+import com.meta.TaskFlow.entities.Proyecto;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProyectoRepository extends JpaRepository<Proyecto, Integer> {
+
+}

--- a/src/main/java/com/meta/TaskFlow/repositories/TareaRepository.java
+++ b/src/main/java/com/meta/TaskFlow/repositories/TareaRepository.java
@@ -1,0 +1,11 @@
+package com.meta.TaskFlow.repositories;
+
+import com.meta.TaskFlow.entities.Tarea;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface TareaRepository extends JpaRepository<Tarea, Integer> {
+    List<Tarea> findByUsuarioId(Integer usuarioId);
+    List<Tarea> findByProyectId(Integer proyectoId);
+}

--- a/src/main/java/com/meta/TaskFlow/repositories/UsuarioRepository.java
+++ b/src/main/java/com/meta/TaskFlow/repositories/UsuarioRepository.java
@@ -1,0 +1,10 @@
+package com.meta.TaskFlow.repositories;
+
+import com.meta.TaskFlow.entities.Usuario;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UsuarioRepository extends JpaRepository<Usuario, Integer> {
+    Optional<Usuario> findByEmail(String email);
+}


### PR DESCRIPTION
### Descripción

Se crean las interfaces de repositorio para las entidades `Usuario`, `Proyecto` y `Tarea` usando Spring Data JPA. Estas interfaces permiten el acceso a base de datos sin escribir queries SQL manuales.

###  Cambios

- `UsuarioRepository`: con método personalizado `findByEmail`
- `ProyectoRepository`: repositorio básico
- `TareaRepository`: incluye métodos para filtrar por usuario o proyecto

Estos repositorios permiten realizar operaciones CRUD y consultas simples en las siguientes capas del proyecto.