### PR TITLE
chore: agregar dependencia spring-boot-starter-validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,10 @@
 			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
Se añade al `pom.xml` la dependencia:

<dependency>
    <groupId>org.springframework.boot</groupId>
    <artifactId>spring-boot-starter-validation</artifactId>
</dependency>

Esta dependencia permite habilitar y usar las anotaciones de validación (`@NotBlank`, `@Email`,` @Valid`, etc.) dentro de las entidades y controladores del proyecto.
