### PR TITLE
feat: agregar manejo global de excepciones

### DIFF
--- a/src/main/java/com/meta/TaskFlow/exceptions/GlobalExceptionsHandler.java
+++ b/src/main/java/com/meta/TaskFlow/exceptions/GlobalExceptionsHandler.java
@@ -1,0 +1,33 @@
+package com.meta.TaskFlow.exceptions;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestControllerAdvice
+public class GlobalExceptionsHandler {
+    // Errores de validación
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, String>> handlerValidationErrors(MethodArgumentNotValidException ex) {
+        Map<String, String> errores = new HashMap<>();
+        ex.getBindingResult().getFieldErrors().forEach(error ->
+                errores.put(error.getField(), error.getDefaultMessage()));
+        return new ResponseEntity<>(errores, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<String> handleIllegalArgument(IllegalArgumentException ex) {
+        return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
+    }
+
+    // Excepciones no controladas
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<String> handleException(Exception ex) {
+        return new ResponseEntity<>("Error interno del servidor: " + ex.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}


### PR DESCRIPTION
Se implementa `GlobalExceptionsHandler` utilizando `@RestControllerAdvice` para capturar y devolver errores de validación, errores de argumentos inválidos y errores no controlados. Esto mejora la experiencia del cliente al recibir respuestas claras y estructuradas ante errores.