### PR TITLE
refactor: aplicar validación con @Valid al crear usuario

### DIFF
--- a/src/main/java/com/meta/TaskFlow/controllers/UsuarioController.java
+++ b/src/main/java/com/meta/TaskFlow/controllers/UsuarioController.java
@@ -2,22 +2,23 @@ package com.meta.TaskFlow.controllers;
 
 import com.meta.TaskFlow.entities.Usuario;
 import com.meta.TaskFlow.services.interfaces.UsuarioService;
+import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.Optional;
 
 @RestController
-@RequestMapping("/TaskFlow" +
-        "/usuarios")
+@RequestMapping("/TaskFlow/usuarios")
 public class UsuarioController {
     @Autowired
     UsuarioService usuarioService;
 
     // Crear nuevo usuario
     @PostMapping
-    public Usuario createUser(@RequestBody Usuario usuario) {
+    public Usuario createUser(@RequestBody @Valid Usuario usuario) {
         return usuarioService.newUser(usuario);
     }
 


### PR DESCRIPTION
Se añade la anotación `@Valid` en el método `createUser` del `UsuarioController`, para asegurar que se apliquen las validaciones declaradas en la entidad `Usuario` al recibir el request.

Esta mejora garantiza que los datos incorrectos no lleguen a la capa de servicio y que el cliente reciba errores claros en caso de entradas inválidas.