### PR TITLE
fix: agregar método de tareas por proyecto en TareaController

### DIFF
--- a/src/main/java/com/meta/TaskFlow/controllers/TareaController.java
+++ b/src/main/java/com/meta/TaskFlow/controllers/TareaController.java
@@ -41,7 +41,7 @@ public class TareaController {
     // Lista de tareas por ID de un proyecto
     @GetMapping("/proyecto/{proyectoId}")
     public List<Tarea> taskByProjectId(@PathVariable Integer projectId) {
-        return tareaService.getTasksbyUserId(projectId);
+        return tareaService.getTaskbyProjectId(projectId);
     }
 
     // Eliminar una tarea por ID


### PR DESCRIPTION
Se corrige un error en el endpoint `GET /TaskFlow/tareas/proyecto/{proyectoId}`, que accidentalmente llamaba al método `getTasksByUserId()` en lugar de `getTasksByProjectId()`. Ahora responde correctamente las tareas asociadas a un proyecto específico.