### PR TITLE
feat: Implementar actualización de estado para tareas

### DIFF
--- a/src/main/java/com/meta/TaskFlow/controllers/TareaController.java
+++ b/src/main/java/com/meta/TaskFlow/controllers/TareaController.java
@@ -1,5 +1,6 @@
 package com.meta.TaskFlow.controllers;
 
+import com.meta.TaskFlow.entities.Estado;
 import com.meta.TaskFlow.entities.Tarea;
 import com.meta.TaskFlow.services.interfaces.TareaService;
 import jakarta.validation.Valid;
@@ -36,18 +37,24 @@ public class TareaController {
     // Lista de tareas por ID de un usuario
     @GetMapping("/usuario/{usuarioId}")
     public List<Tarea> taskByUserId(@PathVariable Integer usuarioId) {
-        return tareaService.getTasksbyUserId(usuarioId);
+        return tareaService.getTasksByUserId(usuarioId);
     }
 
     // Lista de tareas por ID de un proyecto
     @GetMapping("/proyecto/{proyectoId}")
-    public List<Tarea> taskByProjectId(@PathVariable Integer projectId) {
-        return tareaService.getTaskbyProjectId(projectId);
+    public List<Tarea> taskByProjectId(@PathVariable Integer proyectoId) {
+        return tareaService.getTaskByProjectId(proyectoId);
     }
 
     // Eliminar una tarea por ID
     @DeleteMapping("/{id}")
     public void deleteTask(@PathVariable Integer id) {
         tareaService.deleteTask(id);
+    }
+
+    // Actualizar estado de la tarea
+    @PatchMapping("/{id}/estado")
+    public Tarea updateTaskStatus(@PathVariable Integer id, @RequestParam Estado estado) {
+        return tareaService.updateStatus(id, estado);
     }
 }

--- a/src/main/java/com/meta/TaskFlow/services/impl/TareaServiceImpl.java
+++ b/src/main/java/com/meta/TaskFlow/services/impl/TareaServiceImpl.java
@@ -1,11 +1,13 @@
 package com.meta.TaskFlow.services.impl;
 
+import com.meta.TaskFlow.entities.Estado;
 import com.meta.TaskFlow.entities.Tarea;
 import com.meta.TaskFlow.repositories.TareaRepository;
 import com.meta.TaskFlow.services.interfaces.TareaService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import javax.lang.model.util.ElementScanner6;
 import java.util.List;
 import java.util.Optional;
 
@@ -30,17 +32,25 @@ public class TareaServiceImpl implements TareaService {
     }
 
     @Override
-    public List<Tarea> getTasksbyUserId(Integer usuarioId) {
+    public List<Tarea> getTasksByUserId(Integer usuarioId) {
         return tareaRepository.findByUsuarioId(usuarioId);
     }
 
     @Override
-    public List<Tarea> getTaskbyProjectoId(Integer proyectoId) {
+    public List<Tarea> getTaskByProjectId(Integer proyectoId) {
         return tareaRepository.findByProyectoId(proyectoId);
     }
 
     @Override
     public void deleteTask(Integer id) {
         tareaRepository.deleteById(id);
+    }
+
+    @Override
+    public Tarea updateStatus(Integer tareaId, Estado nuevoEstado) {
+        Tarea tarea = tareaRepository.findById(tareaId)
+                .orElseThrow(()-> new IllegalArgumentException("Tarea con ID: " + tareaId + " no encontrada"));
+        tarea.setEstado(nuevoEstado);
+        return tareaRepository.save(tarea);
     }
 }

--- a/src/main/java/com/meta/TaskFlow/services/interfaces/TareaService.java
+++ b/src/main/java/com/meta/TaskFlow/services/interfaces/TareaService.java
@@ -1,5 +1,6 @@
 package com.meta.TaskFlow.services.interfaces;
 
+import com.meta.TaskFlow.entities.Estado;
 import com.meta.TaskFlow.entities.Tarea;
 
 import java.util.List;
@@ -9,7 +10,8 @@ public interface TareaService {
     Tarea newTask(Tarea tarea);
     List<Tarea> getAllTasks();
     Optional<Tarea> getTaskById(Integer id);
-    List<Tarea> getTasksbyUserId(Integer usuarioId);
-    List<Tarea> getTaskbyProjectId(Integer proyectoId);
+    List<Tarea> getTasksByUserId(Integer usuarioId);
+    List<Tarea> getTaskByProjectId(Integer proyectoId);
     void deleteTask(Integer id);
+    Tarea updateStatus(Integer tareaId, Estado nevoEstado);
 }


### PR DESCRIPTION
Se agregó la funcionalidad para actualizar el estado de una tarea mediante un nuevo método en el servicio y un endpoint `PATCH` en el controlador.

Cambios principales:
- Nuevo método updateStatus en TareaService y su implementación.
- Endpoint `PATCH /TaskFlow/tareas/{id}/estado` que permite modificar el estado.
- Manejo de excepción para tareas no encontradas.

Esto permitirá a los usuarios actualizar el progreso de las tareas (pendiente, en progreso, completado) sin necesidad de enviar toda la entidad.
